### PR TITLE
Update links to correct ES comms guide file

### DIFF
--- a/welcoming-new-contributors.md
+++ b/welcoming-new-contributors.md
@@ -17,7 +17,7 @@ This is where you ask the new Contributor about how they've come into the networ
 Based on what you learned in Part 1, suggest three people in the network that the new Contributor might like to connect with. Then empower them to make contact - this could be as simple as saying 'I'd recommend just pinging them on skype - I think they'd be really open to talking with you' or it could involve a personal introduction - either over email or in person.
 
 ## Part 3 : Tour of the house
-If both parties are based in Wellington this could include Enspiral Space, otherwise it will just be a tour of our online spaces. The idea with this part is that it’s the difference between getting given keys to a house and left to your own devices, and being given a personal tour about how everything works. It might also be worth referring them to the **[Enspiral Comms Guide](https://docs.google.com/document/d/1Kj-BI59dqKNK2b1CQ7ZBHcQgFQadh-jQlUxqRTLfQ-8/edit)** at this time.
+If both parties are based in Wellington this could include Enspiral Space, otherwise it will just be a tour of our online spaces. The idea with this part is that it’s the difference between getting given keys to a house and left to your own devices, and being given a personal tour about how everything works. It might also be worth referring them to the **[Enspiral Comms Guide](https://github.com/enspiral/guides/blob/master/comms.md)** at this time.
 
 * **Enspiral website** - where to find essential info. Includes info.enspiral.com and Orientation Doc there.
 

--- a/welcoming-new-contributors.md
+++ b/welcoming-new-contributors.md
@@ -17,7 +17,7 @@ This is where you ask the new Contributor about how they've come into the networ
 Based on what you learned in Part 1, suggest three people in the network that the new Contributor might like to connect with. Then empower them to make contact - this could be as simple as saying 'I'd recommend just pinging them on skype - I think they'd be really open to talking with you' or it could involve a personal introduction - either over email or in person.
 
 ## Part 3 : Tour of the house
-If both parties are based in Wellington this could include Enspiral Space, otherwise it will just be a tour of our online spaces. The idea with this part is that it’s the difference between getting given keys to a house and left to your own devices, and being given a personal tour about how everything works. It might also be worth referring them to the **[Enspiral Comms Guide](https://github.com/enspiral/guides/blob/master/comms.md)** at this time.
+If both parties are based in Wellington this could include Enspiral Space, otherwise it will just be a tour of our online spaces. The idea with this part is that it’s the difference between getting given keys to a house and left to your own devices, and being given a personal tour about how everything works. It might also be worth referring them to the **[Enspiral Comms Guide](comms.md)** at this time.
 
 * **Enspiral website** - where to find essential info. Includes info.enspiral.com and Orientation Doc there.
 


### PR DESCRIPTION
The current link to Enspiral Comms Guide is to a google doc. This has a comment saying it has been moved to Github, if this is true then amend link to go directly to Github file not google doc.
